### PR TITLE
emphasize text displayed when there's no record

### DIFF
--- a/src/components/tabs/Saved.vue
+++ b/src/components/tabs/Saved.vue
@@ -4,7 +4,7 @@
       <div v-if="this.savedRecords.length == 0" class="empty">
         <span role="img">😿</span>
         <p>no saved number</p>
-        <p>When you generate a code you have the option to save locally to your device</p>
+        <p>When you generate a code you have the option to save <strong>locally</strong> to your device</p>
       </div>
 
       <ul id="record-list" v-else class="record-list">


### PR DESCRIPTION
Just to lay emphasis on the fact that records are saved locally on user's device and not in any way saved on some remote server.